### PR TITLE
fixed flaky test io.github.kwahome.sopa.HelperUtilsTests.mapToObjectArrayTest

### DIFF
--- a/src/test/java/io/github/kwahome/sopa/HelperUtilsTests.java
+++ b/src/test/java/io/github/kwahome/sopa/HelperUtilsTests.java
@@ -24,7 +24,7 @@
 
 package io.github.kwahome.sopa;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -42,7 +42,7 @@ import io.github.kwahome.sopa.utils.Helpers;
  */
 public class HelperUtilsTests {
     private Object[] objectArray;
-    private Map<String, Object> map = new HashMap<>();
+    private Map<String, Object> map = new LinkedHashMap<>();
 
     @Before
     public void setUp() {


### PR DESCRIPTION
## What
Fixed flaky test `mapToObjectArrayTest` in ` io.github.kwahome.sopa.HelperUtilsTests`.

The following command was used to detect flakiness using [nondex](https://github.com/TestingResearchIllinois/NonDex):
```
./gradlew --info nondexTest --tests=io.github.kwahome.sopa.HelperUtilsTests.mapToObjectArrayTest --nondexRuns=1
```

**Steps to include nonDex for gradle projects inorder to reproduce the mentioned flakniess:**
Add the following text to the top of the build.gradle:

```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

Add the following line to the end of the build.gradle

```
apply plugin: 'edu.illinois.nondex'
```

If there are subprojects, add the following to the end of the build.gradle

```
subprojects {
  apply plugin: 'edu.illinois.nondex'
}
```

nonDex detects flakiness in the following line of code:

https://github.com/kwahome/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/test/java/io/github/kwahome/sopa/HelperUtilsTests.java#L63

with the error message

> Expected: is ["key2", "value1", "key3", "value2", "key1", "value3"]
         but: was ["key1", "value1", "key2", "value2", "key3", "value3"]

As we can observe, the order of elements is different.

## Why

This happens because ```map``` is declared as a HashMap as shown below.
https://github.com/kwahome/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/test/java/io/github/kwahome/sopa/HelperUtilsTests.java#L45

During the assert we are calling ```Helpers.mapToObjectArray(map)``` and the ```mapToObjectArray``` function iterates through this map as follows:

https://github.com/kwahome/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/main/java/io/github/kwahome/sopa/utils/Helpers.java#L77-L78

As, per the official [docs](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#keySet--) about ```keySet()```, the order of the values returned in not guaranteed for hash maps which can cause non determinism in the output returned.

## Fix

In order to guarantee the order of elements returned when traversed through , I have converted ```map``` to  ```LinkedHashMap```.

```
private Map<String, Object> map = new LinkedHashMap<>();
```

After this change, nonDex does not detect flakiness in the test anymore.

## Test Environment:

> openjdk version "11.0.20.1"
> Apache Maven 3.6.3
> Ubuntu 20.04.6 LTS
> Linux version 5.4.0-156-generic
