### PR TITLE
fixed several flaky tests in test class io.github.kwahome.sopa.StructLoggerKeyValueTests

### DIFF
--- a/src/main/java/io/github/kwahome/sopa/utils/Helpers.java
+++ b/src/main/java/io/github/kwahome/sopa/utils/Helpers.java
@@ -26,7 +26,7 @@ package io.github.kwahome.sopa.utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -51,7 +51,7 @@ public class Helpers {
      * @return Map<String, Object>
      */
     public static Map<String, Object> objectArrayToMap(Object[] objectArray) {
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         for (int i = 0; i < objectArray.length; i = i + 2) {
             map.put((String) Arrays.asList(objectArray).get(i),
                     Arrays.asList(objectArray).get(i + 1));

--- a/src/test/java/io/github/kwahome/sopa/StructLoggerKeyValueTests.java
+++ b/src/test/java/io/github/kwahome/sopa/StructLoggerKeyValueTests.java
@@ -25,6 +25,7 @@
 package io.github.kwahome.sopa;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -112,10 +113,10 @@ public class StructLoggerKeyValueTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -159,10 +160,10 @@ public class StructLoggerKeyValueTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -206,10 +207,10 @@ public class StructLoggerKeyValueTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -253,10 +254,10 @@ public class StructLoggerKeyValueTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -300,10 +301,10 @@ public class StructLoggerKeyValueTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -363,7 +364,7 @@ public class StructLoggerKeyValueTests {
     @Test
     public void loggingHashMapKeyValuesTest() {
         String message = "Hello World!";
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("key1", "value1");
         map.put("key2", "value2");
         logger.info(message, map);
@@ -378,10 +379,10 @@ public class StructLoggerKeyValueTests {
     @Test
     public void loggingMultipleHashMapKeyValuesTest() {
         String message = "Hello World!";
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key1", true);
         map2.put("key2", map1);
         logger.info(message, map1, map2);
@@ -399,10 +400,10 @@ public class StructLoggerKeyValueTests {
         // rather than a map object with key, values to be logged
         String message = "Hello World!";
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject loggableObject = new GenericLoggableObject(new Object[]{"map", map1});
@@ -542,10 +543,10 @@ public class StructLoggerKeyValueTests {
 
         // assert hashmap will work as well
         logger.newBind(); // reset bound context for easier assert
-        Map<String, Object> contextMap1 = new HashMap<>();
+        Map<String, Object> contextMap1 = new LinkedHashMap<>();
         contextMap1.put("key1", "value1");
         contextMap1.put("key2", "value2");
-        Map<String, Object> contextMap2 = new HashMap<>();
+        Map<String, Object> contextMap2 = new LinkedHashMap<>();
         contextMap2.put("key3", "value1");
         contextMap2.put("key4", "value1");
         LoggableObject contextObject = new GenericLoggableObject(new Object[]{"map", contextMap1});


### PR DESCRIPTION
## What
Fixed the following flaky tests in `io.github.kwahome.sopa.StructLoggerKeyValueTests`.
1. logContextBindUpdatesTest
2. logContextUnbindTest
3. loggingAtDebugTest
4. loggingAtErrorTest
5. loggingAtInfoTest
6. loggingAtTraceTest
7. loggingAtWarnTest
8. loggingHashMapKeyValuesTest
9. loggingMixedAllowedLoggableObjectsTest
10. loggingMultipleHashMapKeyValuesTest
11. logNewContextBindingTest

The following command was used to detect flakiness using [nondex](https://github.com/TestingResearchIllinois/NonDex):
```
./gradlew --info nondexTest --tests=io.github.kwahome.sopa.StructLoggerKeyValueTests.logContextBindUpdatesTest --nondexRuns=1
```
Other tests can also be run with nonDex following the above pattern.

**Steps to include nonDex for gradle projects:**
Add the following text to the top of the build.gradle:

```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

Add the following line to the end of the build.gradle

```
apply plugin: 'edu.illinois.nondex'
```

If there are subprojects, add the following to the end of the build.gradle

```
subprojects {
  apply plugin: 'edu.illinois.nondex'
}
```


Across all these tests, nonDex detects flakiness During the assert:

```
Assert.assertThat(actualLoggingEvent, is(expectedLoggingEvent));
```

with the error message

> Expected: is {message=Hello World!, key1=value1, key2=value2, key3=value3},
 but: was {message=Hello World!, key2=value1, key1=value3, key3=value2},

As we can observe, the order of elements is different.

## Why

These elements are declared in the *ObjectArray* ```context``` and the flakiness happens when we try to set ```logger.bind(context);```. Here, internally the method ```objectArrayToMap``` of  *Helper.java* is called which creates a HashMap and appends the values into it. This HashMap is used in ```addParamsToBoundContext``` function of *StructLogger.java* as ```globalLoggerContext``` and ```stringObjectMap```.  Towards the end of this function, we return the following:
https://github.com/kwahome/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/main/java/io/github/kwahome/sopa/StructLogger.java#L320

Here, we are calling the ```Helpers.mapToObjectArray(map)``` helper function to convert the map to an ObjectArray wherein the ```mapToObjectArray``` function iterates through this map as follows:

https://github.com/kwahome/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/main/java/io/github/kwahome/sopa/utils/Helpers.java#L77-L78

As, per the official [docs](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#keySet--) about ```keySet()```, the order of the values returned in not guaranteed for hash maps which can cause non determinism in the output returned.

Similarly, going back to test methods, we also have the following HashMap declarations:
```
Map<String, Object> map1 = new HashMap<>();
map1.put("key1", "value1");
map1.put("key2", "value2");
Map<String, Object> map2 = new HashMap<>();
map2.put("key3", "value1");
map2.put("key4", "value2");
```
These maps are also converted to *ObjectArray* by using the helper function ```Helpers.mapToObjectArray(map)``` which iterates back to the same explanation above.

## Fix

In order to guarantee the order of elements returned when traversed through the map, I have converted ```map1``` and ```map2```  to  ```LinkedHashMap``` in the test methods.

```
Map<String, Object> map1 = new LinkedHashMap<>();
Map<String, Object> map2 = new LinkedHashMap<>();
```
This fix is same across all the 11 test methods mentioned initially.
Also performed the same change in the ```Helper.java``` function ```objectArrayToMap```.

After this change, nonDex does not detect flakiness in the tests anymore.

## Test Environment:

> openjdk version "11.0.20.1"
> Apache Maven 3.6.3
> Ubuntu 20.04.6 LTS
> Linux version 5.4.0-156-generic